### PR TITLE
Add the ability to specific the device name

### DIFF
--- a/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
+++ b/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
@@ -115,22 +115,15 @@ final public class WifiApControl {
 		deviceName = getDeviceName(wm);
 	}
 
-	private WifiApControl(Context context, String deviceName) {
+	private WifiApControl(Context context, String _deviceName) {
 		wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-		this.deviceName = deviceName;
+		deviceName = _deviceName;
 	}
 
 	// getInstance is a standard singleton instance getter, constructing
 	// the actual class when first called.
 	public static WifiApControl getInstance(Context context) {
-		if (instance == null) {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.System.canWrite(context)) {
-				Log.e(TAG, "6.0 or later, but haven't been granted WRITE_SETTINGS!");
-				return null;
-			}
-			instance = new WifiApControl(context);
-		}
-		return instance;
+		return getInstance(context, null);
 	}
 
 	public static WifiApControl getInstance(Context context, String deviceName) {
@@ -139,7 +132,11 @@ final public class WifiApControl {
 				Log.e(TAG, "6.0 or later, but haven't been granted WRITE_SETTINGS!");
 				return null;
 			}
-			instance = new WifiApControl(context, deviceName);
+			if (deviceName == null) {
+				instance = new WifiApControl(context);
+			} else {
+				instance = new WifiApControl(context, deviceName);
+			}
 		}
 		return instance;
 	}

--- a/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
+++ b/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
@@ -207,6 +207,10 @@ final public class WifiApControl {
 		return state;
 	}
 
+	public void setDeviceName(String name) {
+		this.deviceName = name;
+	}
+
 	// getWifiApState returns the current Wi-Fi AP state.
 	// If an error occured invoking the method via reflection, -1 is
 	// returned.

--- a/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
+++ b/library/src/main/java/cc/mvdan/accesspoint/WifiApControl.java
@@ -115,6 +115,11 @@ final public class WifiApControl {
 		deviceName = getDeviceName(wm);
 	}
 
+	private WifiApControl(Context context, String deviceName) {
+		wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+		this.deviceName = deviceName;
+	}
+
 	// getInstance is a standard singleton instance getter, constructing
 	// the actual class when first called.
 	public static WifiApControl getInstance(Context context) {
@@ -124,6 +129,17 @@ final public class WifiApControl {
 				return null;
 			}
 			instance = new WifiApControl(context);
+		}
+		return instance;
+	}
+
+	public static WifiApControl getInstance(Context context, String deviceName) {
+		if (instance == null) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.System.canWrite(context)) {
+				Log.e(TAG, "6.0 or later, but haven't been granted WRITE_SETTINGS!");
+				return null;
+			}
+			instance = new WifiApControl(context, deviceName);
 		}
 		return instance;
 	}
@@ -205,10 +221,6 @@ final public class WifiApControl {
 			return state + 10;
 		}
 		return state;
-	}
-
-	public void setDeviceName(String name) {
-		this.deviceName = name;
 	}
 
 	// getWifiApState returns the current Wi-Fi AP state.


### PR DESCRIPTION
As S7 can have AP and Wifi open at the same time, there is a device called `swlan0` for AP. Therefore, the fallback device name, `wlan0` is not working on S7.

connect #11 